### PR TITLE
Fix bug 2090-2092-2094

### DIFF
--- a/src/main/java/com/avispl/symphony/dal/avdevices/avcontrollers/dalite/screen/controller/common/DaLiteConstant.java
+++ b/src/main/java/com/avispl/symphony/dal/avdevices/avcontrollers/dalite/screen/controller/common/DaLiteConstant.java
@@ -25,7 +25,7 @@ public class DaLiteConstant {
 	public static final String SUBNET_MASK = "SubnetMask";
 	public static final String VLAN = "VLAN";
 	public static final String GATEWAY = "Gateway";
-	public static final String HOSTNAME = "HostName";
+	public static final String HOSTNAME = "Hostname";
 	public static final String NETWORK = "Network";
 	public static final String SCREEN_INFO = "ScreenInfo";
 	public static final String SYSTEM = "System";


### PR DESCRIPTION
Fixed bugs:
- The 'com.avispl.symphony.api.dal.error.CommandFailureException' error is displayed after using controls in the aggregated devices under Neat Pulse
- Issues with Hostname extended property
- The 'PositionCurrentValue(%)' non-controllable property is not displayed in the drawer, when the configManagement: false adapter property is set